### PR TITLE
Add SO_REUSEADDR option to create_server

### DIFF
--- a/server.c
+++ b/server.c
@@ -33,6 +33,12 @@ int create_server(int port) {
     address.sin_addr.s_addr = INADDR_ANY;
     address.sin_port = htons(port);
 
+    int reuse = 1;
+    if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0) {
+        perror("setsockopt");
+        log_error("setsockopt(SO_REUSEADDR) failed");
+    }
+
     if (bind(server_fd, (struct sockaddr *)&address, sizeof(address)) < 0) {
         perror("bind failed");
         exit(EXIT_FAILURE);


### PR DESCRIPTION
## Summary
- allow address reuse on the server socket
- log an error when setsockopt fails

## Testing
- `make clean && make`


------
https://chatgpt.com/codex/tasks/task_e_683f51889c488328b014e169d2487cbd