### PR TITLE
Add optional core/thread args

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,12 @@ gcc -o webserver main.c server.c queue.c request.c logging.c utils.c parseutf.c 
 
 ### Run
 ```bash
-./webserver <filename> [port]
+./webserver <filename> [port] [core_count] [num_threads]
 ```
 - `filename`: The default file to serve (e.g., index.html).
 - `port` (optional): The port on which the server will listen (default: 8080).
+- `core_count` (optional): Number of CPU cores to normalize load against (default: 16).
+- `num_threads` (optional): Number of worker threads to spawn (default: 8).
 
 ### Example
 ```bash

--- a/server.c
+++ b/server.c
@@ -44,11 +44,11 @@ int create_server(int port) {
 void start_server(Server* config) {
     int server_fd = create_server(config->port);
 
-    pthread_t threads[NUM_THREADS];
+    pthread_t *threads = malloc(sizeof(pthread_t) * config->num_threads);
 
     client_queue_init(&client_queue);
 
-    for (int i = 0; i < NUM_THREADS; i++) {
+    for (int i = 0; i < config->num_threads; i++) {
         pthread_create(&threads[i], NULL, worker_thread, config->file);
     }
 

--- a/utils.c
+++ b/utils.c
@@ -7,14 +7,14 @@
 
 void parse_arguments(int argc, char *argv[], Server *config) {
     if (argc < 2) {
-        fprintf(stderr, "Usage: %s <filename> [port]\n", argv[0]);
+        fprintf(stderr, "Usage: %s <filename> [port] [core_count] [num_threads]\n", argv[0]);
         exit(EXIT_FAILURE);
     }
 
     config->file = argv[1];
-    config->port = (argc > 2) ? atoi(argv[2]) : DEFAULT_PORT;    
-    config->core_count = 16;
-    config->num_threads = 8;    
+    config->port = (argc > 2) ? atoi(argv[2]) : DEFAULT_PORT;
+    config->core_count = (argc > 3) ? atoi(argv[3]) : 16;
+    config->num_threads = (argc > 4) ? atoi(argv[4]) : NUM_THREADS;
 }
 
 const char* get_mime_type(const char *filename) {


### PR DESCRIPTION
## Summary
- extend `parse_arguments` to parse optional `core_count` and `num_threads`
- use configured thread count when starting server
- document new usage in README

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_683f5189527c8328a6dd7312b43801b2