### PR TITLE
Refactor HTTP header sending

### DIFF
--- a/request.c
+++ b/request.c
@@ -9,12 +9,11 @@ int is_valid_request(const char *request) {
     return (strstr(request, "GET") == request) && (strstr(request, "HTTP/1.1") || strstr(request, "HTTP/1.0"));
 }
 
-int send_file(FILE *fp, int sockfd) {
+int send_file(FILE *fp, int sockfd, const char *header) {
     char data[BUFFER_SIZE] = {0};
     int n;
 
-    char *http_200 = "HTTP/1.1 200 OK\nContent-Type: text/html\n\n";    
-    if (send(sockfd, http_200, strlen(http_200), 0) == -1) {
+    if (send(sockfd, header, strlen(header), 0) == -1) {
         perror("Failed to send HTTP header");
         return -1;
     }
@@ -30,13 +29,11 @@ int send_file(FILE *fp, int sockfd) {
     return 0;
 }
 
-int send_chunked_file(FILE *fp, int sockfd) {
+int send_chunked_file(FILE *fp, int sockfd, const char *header) {
     char data[BUFFER_SIZE] = {0};
     int n;
 
-    char *http_200_chunked = "HTTP/1.1 200 OK\nContent-Type: text/html\nTransfer-Encoding: chunked\n\n";
-
-    if (send(sockfd, http_200_chunked, strlen(http_200_chunked), 0) == -1) {
+    if (send(sockfd, header, strlen(header), 0) == -1) {
         perror("Failed to send HTTP header");
         return -1;
     }

--- a/server.c
+++ b/server.c
@@ -8,10 +8,10 @@
 #include <sys/socket.h>
 #include "server.h"
 
-const char *http_200 = "HTTP/1.1 200 OK\nContent-Type: %s\r\n\r\n";
-const char *http_400 = "HTTP/1.1 400 BAD REQUEST\nContent-Type: text/html\r\n\r\n";
-const char *http_404 = "HTTP/1.1 404 NOT FOUND\nContent-Type: text/html\r\n\r\n";
-const char *http_500 = "HTTP/1.1 500 INTERNAL SERVER ERROR\nContent-Type: text/html\r\n\r\n";
+const char *http_200 = "HTTP/1.1 200 OK\r\nContent-Type: %s\r\n\r\n";
+const char *http_400 = "HTTP/1.1 400 BAD REQUEST\r\nContent-Type: text/html\r\n\r\n";
+const char *http_404 = "HTTP/1.1 404 NOT FOUND\r\nContent-Type: text/html\r\n\r\n";
+const char *http_500 = "HTTP/1.1 500 INTERNAL SERVER ERROR\r\nContent-Type: text/html\r\n\r\n";
 
 const char *body_400 = "<html><body><h1>400 Bad Request</h1></body></html>";
 const char *body_404 = "<html><body><h1>404 Not Found</h1></body></html>";
@@ -101,7 +101,7 @@ void handle_connection(int client_fd, char *filename) {
         write(client_fd, http_404, strlen(http_404));
         write(client_fd, body_404, strlen(body_404));
     } else {
-        int send_status = send_file(fp, client_fd);
+        int send_status = send_file(fp, client_fd, response_header);
         fclose(fp);
 
         if (send_status < 0) {

--- a/server.h
+++ b/server.h
@@ -62,8 +62,8 @@ Server select_server(Server servers[], int num_servers);
 
 // request
 int is_valid_request(const char *request);
-int send_file(FILE *fp, int sockfd);
-int send_chunked_file(FILE *fp, int sockfd);
+int send_file(FILE *fp, int sockfd, const char *header);
+int send_chunked_file(FILE *fp, int sockfd, const char *header);
 
 // logging
 void log_message(const char *filename, const char *message);


### PR DESCRIPTION
## Summary
- ensure all HTTP header constants use CRLF line endings
- remove local header strings in request helpers
- send the preformatted header from `handle_connection`

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_683f5183ba048328bb3056df0b5b5a26