### PR TITLE
Replace deprecated bzero

### DIFF
--- a/request.c
+++ b/request.c
@@ -25,7 +25,7 @@ int send_file(FILE *fp, int sockfd) {
             return -1;
         }
 
-        bzero(data, BUFFER_SIZE);
+        memset(data, 0, BUFFER_SIZE);
     }
     return 0;
 }
@@ -59,7 +59,7 @@ int send_chunked_file(FILE *fp, int sockfd) {
             return -1;
         }
 
-        bzero(data, BUFFER_SIZE);
+        memset(data, 0, BUFFER_SIZE);
     }
 
     if (send(sockfd, "0\r\n\r\n", 5, 0) == -1) {


### PR DESCRIPTION
## Summary
- update request handler to use `memset`
- keep `<string.h>` include for memset usage

## Testing
- `make clean`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_683f5185cf248328a4ee0b473ca3f531