### PR TITLE
Add .gitignore for generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Compiled binary
+webserver
+
+# Object files
+*.o
+
+# Log files
+*.log
+
+# Additional build artifacts
+*.out
+*.tmp
+*.swp
+*~


### PR DESCRIPTION
## Summary
- Add .gitignore to exclude compiled binary, object files, logs, and other build artifacts.

## Testing
- `make`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_6893c471e23483289dee6c76184cb6f6