### PR TITLE
Improve HTTP request validation

### DIFF
--- a/request.c
+++ b/request.c
@@ -6,7 +6,27 @@
 #include "server.h"
 
 int is_valid_request(const char *request) {
-    return (strstr(request, "GET") == request) && (strstr(request, "HTTP/1.1") || strstr(request, "HTTP/1.0"));
+    const char *ptr;
+    char version[16];
+
+    if (strncmp(request, "GET ", 4) != 0) {
+        return 0;
+    }
+
+    ptr = strchr(request + 4, ' ');
+    if (!ptr) {
+        return 0;
+    }
+
+    if (sscanf(ptr + 1, "%15s", version) != 1) {
+        return 0;
+    }
+
+    if (strcmp(version, "HTTP/1.1") != 0 && strcmp(version, "HTTP/1.0") != 0) {
+        return 0;
+    }
+
+    return 1;
 }
 
 int send_file(FILE *fp, int sockfd, const char *header) {


### PR DESCRIPTION
## Summary
- Parse the request line using `strncmp`/`sscanf`
- Reject requests unless they start with `GET` and include a valid HTTP/1.x version

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6893c47e82c4832886b4dcc0a55bd1be