### PR TITLE
Use thread-safe time formatting in logger

### DIFF
--- a/logging.c
+++ b/logging.c
@@ -1,7 +1,6 @@
 // logging.c
 
 #include <stdio.h>
-#include <string.h>
 #include <time.h>
 #include <stddef.h>
 
@@ -15,8 +14,20 @@ void log_message(const char *filename, const char *message) {
 
     time_t now;
     time(&now);
-    char *time_str = ctime(&now);
-    time_str[strlen(time_str) - 1] = '\0';
+
+    struct tm tm_info;
+    if (localtime_r(&now, &tm_info) == NULL) {
+        perror("Failed to convert time");
+        fclose(log_file);
+        return;
+    }
+
+    char time_str[64];
+    if (strftime(time_str, sizeof(time_str), "%a %b %e %H:%M:%S %Y", &tm_info) == 0) {
+        perror("Failed to format time");
+        fclose(log_file);
+        return;
+    }
 
     fprintf(log_file, "[%s] %s\r\n", time_str, message);
     fclose(log_file);


### PR DESCRIPTION
## Summary
- replace ctime with localtime_r and strftime for thread-safe timestamp formatting
- add error handling for time conversion and formatting

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6893c477b57c8328af19e48d7a7e6349