### PR TITLE
Ensure complete buffer transmission

### DIFF
--- a/request.c
+++ b/request.c
@@ -3,7 +3,23 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#include <errno.h>
 #include "server.h"
+
+static int send_all(int sockfd, const char *buf, size_t len) {
+    size_t total = 0;
+    while (total < len) {
+        ssize_t sent = send(sockfd, buf + total, len - total, 0);
+        if (sent < 0) {
+            if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) {
+                continue;
+            }
+            return -1;
+        }
+        total += (size_t)sent;
+    }
+    return 0;
+}
 
 int is_valid_request(const char *request) {
     return (strstr(request, "GET") == request) && (strstr(request, "HTTP/1.1") || strstr(request, "HTTP/1.0"));
@@ -13,13 +29,13 @@ int send_file(FILE *fp, int sockfd, const char *header) {
     char data[BUFFER_SIZE] = {0};
     int n;
 
-    if (send(sockfd, header, strlen(header), 0) == -1) {
+    if (send_all(sockfd, header, strlen(header)) == -1) {
         perror("Failed to send HTTP header");
         return -1;
     }
 
     while ((n = fread(data, sizeof(char), BUFFER_SIZE, fp)) > 0) {
-        if (send(sockfd, data, n, 0) == -1) {
+        if (send_all(sockfd, data, n) == -1) {
             perror("Failed to send file");
             return -1;
         }
@@ -33,7 +49,7 @@ int send_chunked_file(FILE *fp, int sockfd, const char *header) {
     char data[BUFFER_SIZE] = {0};
     int n;
 
-    if (send(sockfd, header, strlen(header), 0) == -1) {
+    if (send_all(sockfd, header, strlen(header)) == -1) {
         perror("Failed to send HTTP header");
         return -1;
     }
@@ -41,17 +57,17 @@ int send_chunked_file(FILE *fp, int sockfd, const char *header) {
     while ((n = fread(data, sizeof(char), BUFFER_SIZE, fp)) > 0) {
         char chunk_size[10];
         snprintf(chunk_size, sizeof(chunk_size), "%x\r\n", n);
-        if (send(sockfd, chunk_size, strlen(chunk_size), 0) == -1) {
+        if (send_all(sockfd, chunk_size, strlen(chunk_size)) == -1) {
             perror("Failed to send chunk size");
             return -1;
         }
 
-        if (send(sockfd, data, n, 0) == -1) {
+        if (send_all(sockfd, data, n) == -1) {
             perror("Failed to send chunk data");
             return -1;
         }
 
-        if (send(sockfd, "\r\n", 2, 0) == -1) {
+        if (send_all(sockfd, "\r\n", 2) == -1) {
             perror("Failed to send CRLF after chunk");
             return -1;
         }
@@ -59,7 +75,7 @@ int send_chunked_file(FILE *fp, int sockfd, const char *header) {
         memset(data, 0, BUFFER_SIZE);
     }
 
-    if (send(sockfd, "0\r\n\r\n", 5, 0) == -1) {
+    if (send_all(sockfd, "0\r\n\r\n", 5) == -1) {
         perror("Failed to send end of chunked data");
         return -1;
     }


### PR DESCRIPTION
## Summary
- Add helper `send_all` to retry sends on EINTR/EAGAIN/EWOULDBLOCK
- Ensure `send_file` and `send_chunked_file` fully transmit buffers using `send_all`

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6893c4798d708328a233adc0aef3fe82