### PR TITLE
Parse and sanitize request paths

### DIFF
--- a/server.c
+++ b/server.c
@@ -150,11 +150,45 @@ void handle_connection(int client_fd, char *filename) {
         return;
     }
 
+    char requested_path[BUFFER_SIZE] = {0};
+    if (sscanf(buffer, "GET %2047s", requested_path) != 1) {
+        write(client_fd, http_400, strlen(http_400));
+        write(client_fd, body_400, strlen(body_400));
+        close(client_fd);
+        return;
+    }
+
+    char *query = strchr(requested_path, '?');
+    if (query) {
+        *query = '\0';
+    }
+
+    char *path = requested_path;
+    if (path[0] == '/') {
+        path++;
+    }
+
+    if (strstr(path, "..") != NULL) {
+        write(client_fd, http_400, strlen(http_400));
+        write(client_fd, body_400, strlen(body_400));
+        close(client_fd);
+        return;
+    }
+
+    char filepath[BUFFER_SIZE];
+    if (*path == '\0') {
+        strncpy(filepath, filename, sizeof(filepath));
+        filepath[sizeof(filepath) - 1] = '\0';
+    } else {
+        strncpy(filepath, path, sizeof(filepath));
+        filepath[sizeof(filepath) - 1] = '\0';
+    }
+
     char response_header[512];
-    const char *mime_type = get_mime_type(filename);    
+    const char *mime_type = get_mime_type(filepath);
     snprintf(response_header, sizeof(response_header), http_200, mime_type);
 
-    FILE *fp = fopen(filename, "rb");
+    FILE *fp = fopen(filepath, "rb");
     if (fp == NULL) {
         write(client_fd, http_404, strlen(http_404));
         write(client_fd, body_404, strlen(body_404));


### PR DESCRIPTION
## Summary
- Parse HTTP request to extract the requested path
- Sanitize paths to block directory traversal and fall back to default file
- Detect MIME type and open files based on the sanitized path

## Testing
- `make` *(fails: request.c missing <errno.h> and duplicate is_valid_request)*
- `gcc -Wall -pthread -c server.c`


------
https://chatgpt.com/codex/tasks/task_e_68a3bd9ca6b883289112f86c16764933