### PR TITLE
Fix socket failure check in create_server

### DIFF
--- a/server.c
+++ b/server.c
@@ -38,7 +38,8 @@ int create_server(int port) {
     int server_fd;
     struct sockaddr_in address;
 
-    if ((server_fd = socket(AF_INET, SOCK_STREAM, 0)) == 0) {
+    if ((server_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+        // socket returns -1 on failure
         perror("socket failed");
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
## Summary
- Correct socket error handling by checking for negative return values and clarifying failure behavior

## Testing
- `make clean`
- `make` *(fails: 'errno' undeclared in request.c)*
- `gcc -Wall -pthread -c server.c`


------
https://chatgpt.com/codex/tasks/task_e_68a3bd9917308328ad90f0958ede1f62