### PR TITLE
Add document root support and secure file access

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -39,10 +39,10 @@ int client_queue_pop(ClientQueue *q) {
 }
 
 void *worker_thread(void *arg) {
-    char *filename = (char *)arg;
+    const Server *config = (const Server *)arg;
     while (1) {
         int client_fd = client_queue_pop(&client_queue);
-        handle_connection(client_fd, filename);
+        handle_connection(client_fd, config);
     }
     return NULL;
 }

--- a/server.c
+++ b/server.c
@@ -8,14 +8,17 @@
 #include <sys/socket.h>
 #include <signal.h>
 #include <errno.h>
+#include <limits.h>
 #include "server.h"
 
 const char *http_200 = "HTTP/1.1 200 OK\r\nContent-Type: %s\r\n\r\n";
 const char *http_400 = "HTTP/1.1 400 BAD REQUEST\r\nContent-Type: text/html\r\n\r\n";
+const char *http_403 = "HTTP/1.1 403 FORBIDDEN\r\nContent-Type: text/html\r\n\r\n";
 const char *http_404 = "HTTP/1.1 404 NOT FOUND\r\nContent-Type: text/html\r\n\r\n";
 const char *http_500 = "HTTP/1.1 500 INTERNAL SERVER ERROR\r\nContent-Type: text/html\r\n\r\n";
 
 const char *body_400 = "<html><body><h1>400 Bad Request</h1></body></html>";
+const char *body_403 = "<html><body><h1>403 Forbidden</h1></body></html>";
 const char *body_404 = "<html><body><h1>404 Not Found</h1></body></html>";
 const char *body_500 = "<html><body><h1>500 Internal Server Error</h1></body></html>";
 
@@ -82,7 +85,7 @@ void start_server(Server* config) {
     client_queue_init(&client_queue);
 
     for (int i = 0; i < config->num_threads; i++) {
-        int rc = pthread_create(&thread_handles[i], NULL, worker_thread, config->file);
+        int rc = pthread_create(&thread_handles[i], NULL, worker_thread, config);
         if (rc != 0) {
             perror("pthread_create");
             log_error("pthread_create failed");
@@ -132,7 +135,7 @@ void start_server(Server* config) {
     close(server_fd);
 }
 
-void handle_connection(int client_fd, char *filename) {
+void handle_connection(int client_fd, const Server *config) {
     char buffer[BUFFER_SIZE] = {0};
 
     int bytes_read = read(client_fd, buffer, BUFFER_SIZE - 1);
@@ -169,38 +172,78 @@ void handle_connection(int client_fd, char *filename) {
         path++;
     }
 
-    if (strstr(path, "..") != NULL) {
-        write(client_fd, http_400, strlen(http_400));
-        write(client_fd, body_400, strlen(body_400));
+    const char *relative_path = (*path == '\0') ? config->file : path;
+    while (*relative_path == '/') {
+        relative_path++;
+    }
+    if (*relative_path == '\0') {
+        relative_path = config->file;
+    }
+
+    size_t docroot_len = strlen(config->docroot);
+    int docroot_has_trailing_slash = docroot_len > 0 && config->docroot[docroot_len - 1] == '/';
+
+    char candidate_path[PATH_MAX];
+    int required_length;
+    if (docroot_has_trailing_slash) {
+        required_length = snprintf(candidate_path, sizeof(candidate_path), "%s%s", config->docroot, relative_path);
+    } else {
+        required_length = snprintf(candidate_path, sizeof(candidate_path), "%s/%s", config->docroot, relative_path);
+    }
+
+    if (required_length < 0 || (size_t)required_length >= sizeof(candidate_path)) {
+        write(client_fd, http_404, strlen(http_404));
+        write(client_fd, body_404, strlen(body_404));
         close(client_fd);
         return;
     }
 
-    char filepath[BUFFER_SIZE];
-    if (*path == '\0') {
-        strncpy(filepath, filename, sizeof(filepath));
-        filepath[sizeof(filepath) - 1] = '\0';
-    } else {
-        strncpy(filepath, path, sizeof(filepath));
-        filepath[sizeof(filepath) - 1] = '\0';
+    char resolved_path[PATH_MAX];
+    if (realpath(candidate_path, resolved_path) == NULL) {
+        int saved_errno = errno;
+        if (saved_errno == ENOENT || saved_errno == ENOTDIR) {
+            write(client_fd, http_404, strlen(http_404));
+            write(client_fd, body_404, strlen(body_404));
+        } else {
+            write(client_fd, http_403, strlen(http_403));
+            write(client_fd, body_403, strlen(body_403));
+        }
+        close(client_fd);
+        return;
+    }
+
+    int docroot_is_root = (docroot_len == 1 && config->docroot[0] == '/');
+    if (strncmp(resolved_path, config->docroot, docroot_len) != 0 ||
+        (!docroot_is_root && resolved_path[docroot_len] != '\0' && resolved_path[docroot_len] != '/')) {
+        write(client_fd, http_403, strlen(http_403));
+        write(client_fd, body_403, strlen(body_403));
+        close(client_fd);
+        return;
+    }
+
+    FILE *fp = fopen(resolved_path, "rb");
+    if (fp == NULL) {
+        if (errno == EACCES) {
+            write(client_fd, http_403, strlen(http_403));
+            write(client_fd, body_403, strlen(body_403));
+        } else {
+            write(client_fd, http_404, strlen(http_404));
+            write(client_fd, body_404, strlen(body_404));
+        }
+        close(client_fd);
+        return;
     }
 
     char response_header[512];
-    const char *mime_type = get_mime_type(filepath);
+    const char *mime_type = get_mime_type(resolved_path);
     snprintf(response_header, sizeof(response_header), http_200, mime_type);
 
-    FILE *fp = fopen(filepath, "rb");
-    if (fp == NULL) {
-        write(client_fd, http_404, strlen(http_404));
-        write(client_fd, body_404, strlen(body_404));
-    } else {
-        int send_status = send_file(fp, client_fd, response_header);
-        fclose(fp);
+    int send_status = send_file(fp, client_fd, response_header);
+    fclose(fp);
 
-        if (send_status < 0) {
-            write(client_fd, http_500, strlen(http_500));
-            write(client_fd, body_500, strlen(body_500));
-        }
+    if (send_status < 0) {
+        write(client_fd, http_500, strlen(http_500));
+        write(client_fd, body_500, strlen(body_500));
     }
     close(client_fd);
 }

--- a/server.h
+++ b/server.h
@@ -20,9 +20,10 @@
 
 typedef struct {
     char *file;
+    char *docroot;
     int port;
     int core_count;
-    int num_threads;    
+    int num_threads;
 } Server;
 
 typedef enum {
@@ -43,10 +44,12 @@ typedef struct {
 extern const char *http_200;
 
 extern const char *http_400;
+extern const char *http_403;
 extern const char *http_404;
 extern const char *http_500;
 
 extern const char *body_400;
+extern const char *body_403;
 extern const char *body_404;
 extern const char *body_500;
 
@@ -55,7 +58,7 @@ extern ClientQueue client_queue;
 // server
 int create_server(int port);
 void start_server(Server* config);
-void handle_connection(int client_fd, char *filename);
+void handle_connection(int client_fd, const Server *config);
 double get_one_minute_load();
 ServerPriority determine_priority(double one_min_load, int core_count);
 Server select_server(Server servers[], int num_servers);

--- a/utils.c
+++ b/utils.c
@@ -4,15 +4,33 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <limits.h>
+#include <sys/stat.h>
 #include "server.h"
 
 void parse_arguments(int argc, char *argv[], Server *config) {
     if (argc < 2) {
-        fprintf(stderr, "Usage: %s <filename> [port] [core_count] [num_threads]\n", argv[0]);
+        fprintf(stderr, "Usage: %s <filename> [port] [core_count] [num_threads] [docroot]\n", argv[0]);
         exit(EXIT_FAILURE);
     }
 
-    config->file = argv[1];
+    const char *default_file_arg = argv[1];
+    while (*default_file_arg == '/') {
+        default_file_arg++;
+    }
+
+    if (*default_file_arg == '\0') {
+        fprintf(stderr, "Default file must not be empty\n");
+        exit(EXIT_FAILURE);
+    }
+
+    size_t default_len = strlen(default_file_arg);
+    config->file = malloc(default_len + 1);
+    if (config->file == NULL) {
+        perror("Failed to allocate memory for default file path");
+        exit(EXIT_FAILURE);
+    }
+    memcpy(config->file, default_file_arg, default_len + 1);
 
     if (argc > 2) {
         char *endptr;
@@ -52,6 +70,27 @@ void parse_arguments(int argc, char *argv[], Server *config) {
     } else {
         config->num_threads = NUM_THREADS;
     }
+
+    const char *docroot_arg = (argc > 5) ? argv[5] : ".";
+    char resolved_docroot[PATH_MAX];
+    if (realpath(docroot_arg, resolved_docroot) == NULL) {
+        fprintf(stderr, "Invalid document root: %s\n", docroot_arg);
+        exit(EXIT_FAILURE);
+    }
+
+    struct stat docroot_info;
+    if (stat(resolved_docroot, &docroot_info) != 0 || !S_ISDIR(docroot_info.st_mode)) {
+        fprintf(stderr, "Document root must be a directory: %s\n", resolved_docroot);
+        exit(EXIT_FAILURE);
+    }
+
+    size_t docroot_len = strlen(resolved_docroot);
+    config->docroot = malloc(docroot_len + 1);
+    if (config->docroot == NULL) {
+        perror("Failed to allocate memory for document root");
+        exit(EXIT_FAILURE);
+    }
+    memcpy(config->docroot, resolved_docroot, docroot_len + 1);
 }
 
 const char* get_mime_type(const char *filename) {


### PR DESCRIPTION
## Summary
- add document root configuration to the server setup and argument parsing
- resolve requested paths against the document root and return 403/404 when access fails
- pass full server configuration to worker threads so default content obeys the document root restrictions

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68e07afc4f9c832884ed438148ab67d3